### PR TITLE
Keymap revamp

### DIFF
--- a/config/corne.conf
+++ b/config/corne.conf
@@ -1,6 +1,6 @@
-# Uncomment the following lines to enable the Corne RGB Underglow
-# CONFIG_ZMK_RGB_UNDERGLOW=y
-# CONFIG_WS2812_STRIP=y
+# Author: Ryan H.
+# Filename: corne.conf
+# Holds ZMK config settings for Corne keyboard.
 
 # Enable sleep functionality
 CONFIG_ZMK_SLEEP=y

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: MIT
  */
 
+// Author: Ryan H.
+// Filename: corne.keymap
+// Keymap settings for a 3x6 column Corne.
+// Currently setup for a 3x5 column variant and only 2 thumb keys.
+
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -46,50 +46,50 @@
         };
     };
 
-        keymap {
-                compatible = "zmk,keymap";
-                default_layer {
-                  label = "Base";
+    keymap {
+        compatible = "zmk,keymap";
+        default_layer {
+            label = "Base";
 // -----------------------------------------------------------------------------------------
-// | TAB   |  Q  |  W  |  E  |  R  |  T  |   |  Y  |  U   |  I  |  O  |  P  | BSLH |
-// | DEL   |  A  |  S  |  D  |  F  |  G  |   |  H  |  J   |  K  |  L  |  ;  |  '   |
-// | LSHFT |  Z  |  X  |  C  |  V  |  B  |   |  N  |  M   |  ,  |  .  |  /  | RALT |
-//             | GUI | LCTRL | LOWER/SPC |   | RAISE/ENT | BSPC  | ESC |
-                        bindings = <
-   &kp TAB   &kp Q &kp W &kp E &kp R &kp T   &kp Y &kp U  &kp I     &kp O   &kp P    &kp BSLH
-   &kp DEL   &kp A &kp S &kp D &kp F &kp G   &kp H &kp J  &kp K     &kp L   &kp SEMI &kp SQT
-   &kp LSHFT &kp Z &kp X &kp C &kp V &kp B   &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &kp RALT
-        &kp LGUI &kp LCTRL &lt LOWER SPACE   &lt RAISE RET &kp BSPC &kp ESC
+// |    |  Q  |  W  |  E  |  R  |  T  |   |  Y  |  U   |  I  |  O  |  P  |    |
+// |    |  A  |  S  |  D  |  F  |  G  |   |  H  |  J   |  K  |  L  |  ;  |    |
+// |    |  Z  |  X  |  C  |  V  |  B  |   |  N  |  M   |  ,  |  .  |  /  |    |
+//            |     | TAB | SPC/LOWER |   | ENT/UPPER | BSPC |     |
+            bindings = <
+   &none &kp Q      &kp W      &kp E       &kp R       &kp T   &kp Y &kp U       &kp I       &kp O      &kp P         &none
+   &none &hm LGUI A &hm LALT S &hm LSHFT D &hm LCTRL F &kp G   &kp H &hm RCTRL J &hm RSHFT K &hm RALT L &hm RGUI SEMI &none
+   &none &kp Z      &kp X      &kp C       &kp V       &kp B   &kp N &kp M       &kp COMMA   &kp DOT    &kp FSLH      &none
+                               &none &kp TAB &lt LOWER SPACE   &lt UPPER RET &kp BSPC &none
                         >;
                 };
 
-                lower_layer {
-                  label = "Lower";
+        lower_layer {
+            label = "Lower";
 // -----------------------------------------------------------------------------------------
-// | ESC   |  1  |  2  |  3  |  4  |  5  |   |  6  |  7  |  8  |  9  |  0  |     |
-// | BTCLR | BT1 | BT2 | BT3 | BT4 | BT5 |   | LFT | DWN |  UP | RGT |     |     |
-// | F1    | F2  | F3  | F4  | F5  | F6  |   | F7  | F8  | F9  | F10 | F11 | F12 |
-//                     |     |     |     |   |     |     |     |
-                        bindings = <
-   &kp ESC    &kp N1       &kp N2       &kp N3       &kp N4       &kp N5         &kp N6   &kp N7   &kp N8 &kp N9    &kp N0  &trans
-   &bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4   &kp LEFT &kp DOWN &kp UP &kp RIGHT &trans  &trans
-   &kp F1     &kp F2       &kp F3       &kp F4       &kp F5       &kp F6         &kp F7   &kp F8   &kp F9 &kp F10   &kp F11 &kp F12
-                                        &trans       &trans       &trans         &trans   &trans   &trans
+// |     | 1 ! | 2 @ | 3 # | 4 $ | 5 % |   | 6 ^  | 7 &  | 8 *  | 9 ( | 0 )  |     |
+// |     | \ | | = + | - _ | ` ~ | ' " |   | LFT  | DWN  |  UP  | RGT | CAPS |     |
+// |     |     |     |PSCRN| [ { | ] } |   | HOME | PGDN | PGUP | END | INS  |     |
+//                   |     |     |     |   |      | DEL  |      |
+            bindings = <
+   &trans AS(N1)   AS(N2)    AS(N3)    AS(N4)    AS(N5)    AS(N6)   AS(N7)    AS(N8)    AS(N9)    AS(N0)   &trans
+   &trans AS(BSLH) AS(EQUAL) AS(MINUS) AS(GRAVE) AS(SQT)   &kp LEFT &kp DOWN  &kp UP    &kp RIGHT &kp CAPS &trans
+   &trans &trans   &trans    &kp PSCRN AS(LBKT)  AS(RBKT)  &kp HOME &kp PG_DN &kp PG_UP &kp END   &kp INS  &trans
+                             &trans    &trans    &trans    &trans   &kp DEL   &trans
                         >;
                 };
 
-                raise_layer {
-                  label = "Raise";
+        upper_layer {
+            label = "Upper";
 // -----------------------------------------------------------------------------------------
-// | ESC  |  !   |  @   |  #   |   $  |  %  |   |  ^  |  &  |  *  |  (  |  )  |     |
-// | CAPS | BRI- | BRI+ | HOME | END  |     |   |  `  |  -  |  =  |  {  |  }  |  \  |
-// | INS  | PREV | NEXT | VOL- | VOL+ | PP  |   |  ~  |  _  |  +  |  [  |  ]  |  |  |
-//                      |      |      |     |   |     |     |     |
-                        bindings = <
-   &kp ESC   &kp EXCL     &kp AT       &kp HASH     &kp DLLR     &kp PRCNT   &kp CARET &kp AMPS  &kp KP_MULTIPLY &kp LPAR &kp RPAR &trans
-   &kp CLCK  &kp C_BRI_DN &kp C_BRI_UP &kp HOME     &kp END      &trans      &kp GRAVE &kp MINUS &kp EQUAL       &kp LBRC &kp RBRC &kp BSLH
-   &kp INS   &kp C_PREV   &kp C_NEXT   &kp C_VOL_DN &kp C_VOL_UP &kp C_PP    &kp TILDE &kp UNDER &kp PLUS        &kp LBKT &kp RBKT &kp PIPE
-                                               &trans   &trans   &trans      &trans    &trans    &trans
+// |     | F1  | F2  | F3  | F4  | F5  |   | BT5  | BT4  | BT3  | BT2  | BT1  |     |
+// |     | F6  | F7  | F8  | F9  | F10 |   | PP   | VOL- | VOL+ | PREV | NEXT |     |
+// |     | F11 | F12 | F13 | F14 | F15 |   | BRI- | BRI+ |      |      |BTCLR |     |
+//                   |     | ESC |     |   |      |      |      |
+            bindings = <
+   &trans &kp F1  &kp F2  &kp F3  &kp F4  &kp F5    &bt BT_SEL 4 &bt BT_SEL 3 &bt BT_SEL 2 &bt BT_SEL 1 &bt BT_SEL 0 &trans
+   &trans &kp F6  &kp F7  &kp F8  &kp F9  &kp F10   &kp C_PP     &kp C_VOL_DN &kp C_VOL_UP &kp C_PREV   &kp C_NEXT   &trans
+   &trans &kp F11 &kp F12 &kp F13 &kp F14 &kp F15   &trans       &kp C_BRI_DN &kp C_BRI_UP &kp LBKT     &kp RBKT     &trans
+                          &trans  &kp ESC &trans    &trans       &trans       &trans
                         >;
                 };
         };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -15,7 +15,13 @@
 
 #define BASE 0
 #define LOWER 1
-#define RAISE 2
+#define UPPER 2
+
+#define AS(keycode) &as LS(keycode) keycode     // Autoshift Macro
+
+&lt {
+    tapping-term-ms = <150>;
+};
 
 / {
         keymap {

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -24,6 +24,28 @@
 };
 
 / {
+    behaviors {
+        hm: homerow_mods {
+            compatible = "zmk,behavior-hold-tap";
+            label = "HOMEROW_MODS";
+            #binding-cells = <2>;
+            tapping-term-ms = <150>;
+            quick-tap-ms = <0>;
+            flavor = "tap-preferred";
+            bindings = <&kp>, <&kp>;
+        };
+
+        as: auto_shift {
+            compatible = "zmk,behavior-hold-tap";
+            label = "AUTO_SHIFT";
+            #binding-cells = <2>;
+            tapping_term_ms = <125>;
+            quick_tap_ms = <0>;
+            flavor = "tap-preferred";
+            bindings = <&kp>, <&kp>;
+        };
+    };
+
         keymap {
                 compatible = "zmk,keymap";
                 default_layer {


### PR DESCRIPTION
Overhauled `corne.keymap` to only use 5 columns instead of 6 and 2 thumb keys instead of 3.